### PR TITLE
Add CODEOWNERS file for AI app compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @alchemyplatform/wallet-services


### PR DESCRIPTION
Adds CODEOWNERS requiring human review from: **@alchemyplatform/wallet-services**

**Why:** AI apps removed due to lack of CODEOWNERS ([PR #505](https://github.com/OMGWINNING/terraform-github/pull/505), [#503](https://github.com/OMGWINNING/terraform-github/pull/503)). Without CODEOWNERS, AI bots can self-approve PRs.

**Selection:** wallet-services: 15 members, write_team

**To regain AI access:**
1. Merge this PR
2. Enable branch protection: Settings → Branches → "Require review from Code Owners"
3. Request re-enablement via [terraform-github](https://github.com/OMGWINNING/terraform-github)

[Compliance report](https://gist.github.com/mjbenedict-alchemy/2b55685bb5f018db89bcd636616e4157) | Contact: @michael.benedict or #cloud-infra-reviews